### PR TITLE
Support changing service types

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: "v1"
 name: "gamebench"
-version: "0.2"
+version: "0.3"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ helm install --namespace <namespace> gamebench-web-dashboard web-dashboard-helm-
 | `api.image.pullSecrets` | Array of kubernetes pull secret names | `[]` |
 | `api.livenessProbe` | API liveness probe  | `{"httpGet":{"path":"/v1/health","port":5000},"initialDelaySeconds":60,"periodSeconds":30}` |
 | `api.resources` | CPU/Memory resource requests/limits  | `{}` |
+| `api.service.type` | API Service Type | `"ClusterIP"` | 
 | `apiTokenSecret` | Key used to hash API tokens  | `""` |
 | `application.host` | Application host. Used to construct URLs to the application  | `""` |
 | `application.port` | Application port. Used to construct URLs to the application  | `""` |
@@ -77,6 +78,7 @@ helm install --namespace <namespace> gamebench-web-dashboard web-dashboard-helm-
 | `ui.image.repository` | Frontend image repository  | `quay.io/gamebench/ang4-frontend` |
 | `ui.image.pullSecrets` | Array of kubernetes pull secret names | `[]` |
 | `ui.resources` | CPU/Memory resource requests/limits  | `{}` |
+| `ui.service.type` | UI Service Type | `"ClusterIP"` |
 | `worker.resources` | CPU/Memory resource requests/limits  | `{}` |
 
 ## Troubleshooting

--- a/templates/api-service.yaml
+++ b/templates/api-service.yaml
@@ -9,6 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  type: {{ .Values.api.service.type }}
   ports:
   - name: http
     port: 5000

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -9,6 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  type: {{ .Values.ui.service.type }}
   ports:
   - name: http
     port: 80

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,8 @@ api:
   #    cpu: 1
   #  limits:
   #    memory: 1Gi
+  service:
+    type: ClusterIP
 
 apiTokenSecret: ""
 application:
@@ -70,6 +72,8 @@ ui:
   #    cpu: 250m
   #  limits:
   #    memory: 512Mi
+  service:
+    type: ClusterIP
 
 worker:
   replicas: 1


### PR DESCRIPTION
This PR allows the changing of service types.

In my case, using Ingress with Google Container Engine, you cannot use ClusterIP services. Changing this to NodePort works.