### PR TITLE
license.contents should be base64 encoded

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: "v1"
 name: "gamebench"
-version: "0.3"
+version: "0.4"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: "v1"
 name: "gamebench"
-version: "0.4"
+version: "0.5"

--- a/templates/license-secret.yaml
+++ b/templates/license-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  gamebench-license: {{ .Values.license.contents | b64enc | quote }}
+  gamebench-license: {{ .Values.license.contents | quote }}
   gamebench-license.RSA-SHA256: {{ .Values.license.signature | quote }}
 kind: Secret
 metadata:


### PR DESCRIPTION
To simplify the handling of the license file contents, which are JSON, they should be base64 encoded in the same way the signature is. This prevents automation tools from trying to interpret or modify the license.

This PR should be considered a breaking change, so you may want to bump the major version number of the chart instead of the v0.4 I increased it to.