### PR TITLE
Adding custom pod annotations functionality

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -22,6 +22,9 @@ spec:
         release: "{{ .Release.Name }}"
         component: api
       annotations:
+      {{- with .Values.api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:

--- a/templates/ui-deployment.yaml
+++ b/templates/ui-deployment.yaml
@@ -21,7 +21,6 @@ spec:
         app: {{ template "gamebench.name" . }}
         release: "{{ .Release.Name }}"
         component: ui
-      {{- if .Values.ui.podAnnotations }}
       annotations:
       {{- with .Values.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/templates/ui-deployment.yaml
+++ b/templates/ui-deployment.yaml
@@ -21,6 +21,11 @@ spec:
         app: {{ template "gamebench.name" . }}
         release: "{{ .Release.Name }}"
         component: ui
+      {{- if .Values.ui.podAnnotations }}
+      annotations:
+      {{- with .Values.ui.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.ui.image.pullSecrets }}
       imagePullSecrets:

--- a/templates/ui-deployment.yaml
+++ b/templates/ui-deployment.yaml
@@ -21,8 +21,8 @@ spec:
         app: {{ template "gamebench.name" . }}
         release: "{{ .Release.Name }}"
         component: ui
-      annotations:
       {{- with .Values.ui.podAnnotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -22,6 +22,9 @@ spec:
         release: "{{ .Release.Name }}"
         component: worker
       annotations:
+      {{- with .Values.worker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,6 @@
 api:
+  podAnnotations: {}
+  #  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   image:
     repository: quay.io/gamebench/node-backend
     pullSecrets: []
@@ -78,6 +80,8 @@ smtp:
   port: ""
   tls: ""
 ui:
+  podAnnotations: {}
+  #  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   image:
     repository: quay.io/gamebench/ang4-frontend
     pullSecrets: []
@@ -92,6 +96,8 @@ ui:
     type: ClusterIP
 
 worker:
+  podAnnotations: {}
+  #  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   replicas: 1
   resources: {}
   #  requests:


### PR DESCRIPTION
To eliminate errors with Kubernetes scheduler like 
`Pod is blocking scale down because it has local storage `
We need to add an annotation to pods that contain storage type emptyDir.
`cluster-autoscaler.kubernetes.io/safe-to-evict=true`
It will give the ability to the Kubernetes scheduler to manage loads across worker nodes in a more efficient way.
The deployments affected by this issue:
- api-deployment
- worker-deployment